### PR TITLE
fixed code range and 404 link

### DIFF
--- a/content/guides/ethereum/tutorials/track_trx.md
+++ b/content/guides/ethereum/tutorials/track_trx.md
@@ -4,10 +4,10 @@ menuTitle: Track transaction in real-time
 title: Track transaction in Real-time
 release: beta
 ---
-In this guide we will create a simple React application that will use dfuse's Transaction State Tracker API to keep track of the state of an Ethereum transaction in real time. We will be using {{< external-link href="https://reactjs.org/docs/hooks-intro.html" title="react hooks">}}.
+In this guide we will create a simple React application that will use dfuse's Transaction State Tracker API to keep track of the state of an Ethereum transaction in real time. To do that, we will be using {{< external-link href="https://reactjs.org/docs/hooks-intro.html" title="react hooks">}}.
 
 {{< alert type="note" >}}
-Installing {{< external-link href="https://reactjs.org/tutorial/tutorial.html#developer-tools" title="React Dev Tools">}} for your browser is optional, but is very useful for seeing what goes on in the application
+Installing the {{< external-link href="https://reactjs.org/tutorial/tutorial.html#developer-tools" title="React Dev Tools">}} plugin for your browser is optional, but is very useful for seeing what goes on in the application.
 {{< /alert >}}
 
 
@@ -31,7 +31,7 @@ then open ({{< external-link href="http://localhost:3000/">}})
 
 ## 3. Add the dfuse Client Library
 
-The simplest way to get started with dfuse and JavaScript/TypeScript development is to use the dfuse JS client library.
+The simplest way to get started with dfuse and JavaScript/TypeScript development is to use the dfuse JS Client Library.
 
 {{< tabs "adding-dfuse-client-lib">}}
 {{< tab title="NPM" lang="shell" >}}
@@ -42,77 +42,67 @@ npm install --save @dfuse/client
 
 ## 4. Setup dfuse Client
 
-Import the necessary functions from `dfuse/client` at the top of `src/App.js`
+Import the necessary functions from `dfuse/client` at the top of `src/App.js`.
 
 {{< tabs "setting-up-dfuse-client1-import">}}
 {{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="1:3" >}}
 {{< /tabs >}}
 
-Initialize the dfuse client using the API key you created in the second step. Lets create the `dfuseClient` right after the `function App()` declaration.
+Initialize the dfuse client using the API key you created in the second step. Let's create the `dfuseClient` right after the `function App()` declaration.
 
 {{< tabs "setting-up-dfuse-client1-initialize">}}
-{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="6:10" >}}
+{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="6:9" >}}
 {{< /tabs >}}
 
-## 5. Craft the graphQL query
+## 5. Craft the GraphQL query
 
 To get a real-time feed of transaction state changes, we need to craft a GraphQL subscription query. A GraphQL subscription will continuously stream responses and allows you to pick and choose the fields you want to return in the messages.
 
 {{< alert type="note" >}}
-See {{< external-link title="Graphql Concept" href="/guides/core-concepts/graphql/">}} for more information about GraphQL
+See [Getting Started with GraphQL](/guides/core-concepts/graphql/) for more information about GraphQL.
 {{< /alert >}}
 
 Our GraphQL query will use the `transactionLifecycle` with a `hash` filter to retrieve the state changes of the transaction.
 
 {{< alert type="tip" >}}
-Do not worry! This query may seem intimidating, but it is broken down in  {{< external-link title="Transaction State Tracker Concept" href="/guides/ethereum/concepts/trx_state_tracker/">}}
+Do not worry! This query may seem intimidating, but it is broken down using the [Transaction State Tracker Concept](/guides/ethereum/concepts/trx_lifecycle/).
 {{< /alert >}}
 
 {{< tabs "tracker-query">}}
-{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="11:121" >}}
+{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="11:122" >}}
 {{< /tabs >}}
 
-## 6. Setup Our Hooks
+## 6. Setup our Hooks
 
 Lets setup a few hooks that will help us keep track of our transaction states and render our component. We use {{< external-link title="react state hook" href="https://reactjs.org/docs/hooks-state.html">}} to accomplish this.
 
 * `transactionHash`: keeps track of the transaction's hash
 * `transitions`: array that stores all the received transaction transitions
-* `state`: store the current state of the GraphQL subscription
-* `error`: store our errors
+* `state`: stores the current state of the GraphQL subscription
+* `error`: stores our errors
 
 {{< tabs "setup-hooks">}}
-{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="123:126" >}}
+{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="124:127" >}}
 {{< /tabs >}}
 
 ## 7. Get a Transaction State
 
-Create an `async` function `fetchTransactionState` that will use dfuse JS client to execute the GraphQL query we crafted above.
-
-{{< tabs "fetch-transaction-func">}}
-{{< tab title="src/App.js" lang="javascript" >}}
-    async function fetchTransaction() {
-        ...
-    }
-{{< /tab >}}
-{{< /tabs >}}
-
-Initialize a few state variables.
+Create an `async` function `fetchTransaction` that will use the dfuse JS client to execute the GraphQL query we crafted above and initialize a few state variables.
 
 {{< tabs "fetch-transaction-init">}}
 {{< tab title="src/App.js" lang="javascript" >}}
     async function fetchTransaction() {
-        setState("streaming");
-        setError("");
-        setTransitions([]);
-        var currentTransitions = [];
-        var count = 0;
+        setState("streaming");          // sets the state of our query to "streaming"
+        setError("");                   // clears any errors that may have been logged before
+        setTransitions([]);             // clears the transitions when starting a new search
+        var currentTransitions = [];    // local variable to store transition in callback function
+        var count = 0;                  // reset transition count
         ...
     }
 {{< /tab >}}
 {{< /tabs >}}
 
-Use the dfuse client with GraphQL query and set our transaction hash as a variable.
+Use the dfuse client with the GraphQL query and set our transaction hash as a variable.
 
 {{< tabs "fetch-transaction-func-setup">}}
 {{< tab title="src/App.js" lang="javascript" >}}
@@ -130,7 +120,7 @@ Use the dfuse client with GraphQL query and set our transaction hash as a variab
                 hash:  transactionHash
             }
         });
-        await stream.join();
+        await stream.join();  // continues until disconnect and complete
     }
 {{< /tab >}}
 {{< /tabs >}}
@@ -142,7 +132,7 @@ The `message` returned from the GraphQL stream can have 3 different types that n
 * `complete`: This message occurs when the stream is closed. We update our stream state.
 
 {{< tabs "fetch-transaction-func-handler">}}
-{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="128:164" >}}
+{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="129:165" >}}
 {{< /tabs >}}
 
 ## 8. Render Function
@@ -150,10 +140,10 @@ The `message` returned from the GraphQL stream can have 3 different types that n
 Build the `render` method for this component. It will include an input for the transaction hash, and handles the different possible states of our component.
 
 {{< tabs "fetch-transaction-render">}}
-{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="166:202" >}}
+{{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="167:203" >}}
 {{< /tabs >}}
 
-## 9. Prettifying it With CSS
+## 9. Prettifying it with CSS
 
 Add some CSS to style this HTML a bit. Replace the contents of `src/App.css` with the following:
 
@@ -163,7 +153,7 @@ Add some CSS to style this HTML a bit. Replace the contents of `src/App.css` wit
 
 ## 10. Full Working Example
 
-The source code for this tutorial is available on {{< external-link href="https://github.com/dfuse-io/docs/tree/master/tutorials/ethereum/track_tx" title="GitHub here" >}} . Here are the code files discussed on this page.
+The source code for this tutorial is available on {{< external-link href="https://github.com/dfuse-io/docs/tree/master/tutorials/ethereum/track_tx" title="GitHub" >}}. Below are the code files discussed on this page.
 
 {{< tabs "fetch-transaction-full-app">}}
 {{< tab-code title="src/App.js" filename="./tutorials/ethereum/track_tx/App.js" range="1:206" >}}


### PR DESCRIPTION
FIXED
- some code ranges were off by 1-2 lines, so going through the tutorial line by line didn't work
- the Transaction State Tracker Concept link was giving a 404, changed to correct(?) link
- internal links now acting as internal links instead of external links
- some minor copy tweaks